### PR TITLE
Chapter5

### DIFF
--- a/chapter5/kadai.go
+++ b/chapter5/kadai.go
@@ -1,0 +1,90 @@
+package chapter5
+
+import (
+	"bufio"
+	"bytes"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+)
+
+type cutEntity struct {
+	args      []string
+	delimiter string
+	fields    int
+}
+
+var delimiter = flag.String("d", ",", "区切り文字を指定してください")
+var fields = flag.Int("f", 1, "フィールドの何番目を取り出すか指定してください")
+
+// go-cutコマンドを実装しよう
+func main() {
+	flag.Parse()
+
+	cutEntity := cutEntity{
+		args:      flag.Args(),
+		delimiter: *delimiter,
+		fields:    *fields,
+	}
+
+	err := Validate(cutEntity)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	file, err := os.Open(cutEntity.args[0])
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer file.Close()
+
+	err = Cut(cutEntity, file, os.Stdout)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+func Cut(cutEntity cutEntity, r io.Reader, w io.Writer) error {
+
+	// この部分をCutコマンドとして関数2つ目に切り出す------
+	// ヒント：NewScannerにfileを渡しているが、NewScannerはio.Readerであれば何でも良い
+	// また、出力も現在fmt.Println(s)にしているが、io.Writerを使って書き出す先を指定できるようにしてやる
+	// 関数の引数で読み出すio.Readerと、
+	// 書き出すio.Writer (本関数からはos.Stdout, テストからはbyte.Bufferなどへ)を指定できるようにすると良い
+	bw := bufio.NewWriter(w)
+	defer bw.Flush()
+
+	scanner := bufio.NewScanner(r)
+	delimiter := []byte(cutEntity.delimiter)
+	for scanner.Scan() {
+		btext := scanner.Bytes()
+		sb := bytes.Split(btext, delimiter)
+		if len(sb) < cutEntity.fields {
+			return fmt.Errorf("-fの値に該当するデータがありません")
+		}
+		b := sb[cutEntity.fields-1]
+		_, err := bw.Write(b)
+		if err != nil {
+			return err
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	return nil
+	// ------------------------------------------------
+}
+
+func Validate(cutEntity cutEntity) error {
+	// このValidationを関数1つ目に切り出す ---------
+	// ヒント：flagの内容を渡してやって、バリデーションし、エラーがあれば返すような関数にできる
+	if len(cutEntity.args) == 0 {
+		return fmt.Errorf("ファイルパスを指定してください。")
+	}
+	if cutEntity.fields < 0 {
+		return fmt.Errorf("-f は1以上である必要があります")
+	}
+	return nil
+	// ---------------------------------------
+}

--- a/chapter5/kadai_test.go
+++ b/chapter5/kadai_test.go
@@ -1,0 +1,108 @@
+package chapter5
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   cutEntity
+		isError bool
+	}{
+		{
+			name: "成功",
+			input: cutEntity{
+				args:      []string{"test1"},
+				delimiter: ",",
+				fields:    1,
+			},
+			isError: false,
+		},
+		{
+			name: "要素なし",
+			input: cutEntity{
+				args:      nil,
+				delimiter: ",",
+				fields:    1,
+			},
+			isError: true,
+		},
+		{
+			name: "該当データなし",
+			input: cutEntity{
+				args:      []string{"test3"},
+				delimiter: ",",
+				fields:    -1,
+			},
+			isError: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.isError {
+				assert.Error(t, Validate(test.input))
+			} else {
+				assert.NoError(t, Validate(test.input))
+			}
+		})
+	}
+}
+
+func TestCut(t *testing.T) {
+
+	type input struct {
+		cutEntity
+		str io.Reader
+	}
+
+	tests := []struct {
+		name    string
+		input   input
+		expect  string
+		isError bool
+	}{
+		{
+			name: "成功",
+			input: input{
+				cutEntity: cutEntity{
+					args:      []string{"test1"},
+					delimiter: "/",
+					fields:    1,
+				},
+				str: bytes.NewBufferString("aaaaa/bbbbb"),
+			},
+			expect:  "aaaaa",
+			isError: false,
+		},
+		{
+			name: "要素なし",
+			input: input{
+				cutEntity: cutEntity{
+					args:      []string{"test2"},
+					delimiter: ",",
+					fields:    3,
+				},
+				str: bytes.NewBufferString("aaaaa/bbbbb"),
+			},
+			expect:  "",
+			isError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var out bytes.Buffer
+			if test.isError {
+				assert.Error(t, Cut(test.input.cutEntity, test.input.str, &out))
+			} else {
+				assert.NoError(t, Cut(test.input.cutEntity, test.input.str, &out))
+				assert.Equal(t, test.expect, out.String())
+			}
+		})
+	}
+}

--- a/chapter5/kadai_test.go
+++ b/chapter5/kadai_test.go
@@ -3,6 +3,7 @@ package chapter5
 import (
 	"bytes"
 	"io"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -104,5 +105,33 @@ func TestCut(t *testing.T) {
 				assert.Equal(t, test.expect, out.String())
 			}
 		})
+	}
+}
+
+func BenchmarkCut(b *testing.B) {
+	entity := cutEntity{
+		delimiter: ":",
+		fields:    1,
+	}
+	str := bytes.NewBufferString("aaaaaa:bbbbbb")
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		Cut(entity, str, os.Stdout)
+	}
+}
+
+func BenchmarkValidate(b *testing.B) {
+	entity := cutEntity{
+		args:      []string{"test1", "test1"},
+		delimiter: ":",
+		fields:    1,
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		Validate(entity)
 	}
 }


### PR DESCRIPTION
# chapter5
q1 - q2解いた！
写景しつつ、噛み砕きながらといた。

## メモ

- goの小文字始まりはprivate、範囲は同じpackage
(privateの範囲、java脳的にもっと範囲狭いかと思ってたけど、意外と広かった)

- io.Reader
`file, err := os.Open()`の返り値の`file`は`*File`型だけど`io.Reader`のinterface持ってる
`os.Stdin`とかも`io.Reader`の`interface`もっているので標準入力でcutもすぐに実装できそう
  - https://qiita.com/umesyusower/items/ddf6920a484e74f0ee1a

- io.Writer
こちらも、io.Writerのinterfaceを引数にしているので、
出力先を`file`や`stdout`, `bytes.Buffer`で変数にも変更できる
https://qiita.com/umesyusower/items/2425fa2a70572c088f4a

